### PR TITLE
Add support for interactive search

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -35,18 +35,28 @@ function init() {
 }
 
 function listProcesses(processes) {
+	inquirer.registerPrompt('autocomplete', require('inquirer-autocomplete-prompt'));
+
 	inquirer.prompt([{
 		name: 'processes',
 		message: 'Running processes:',
-		type: 'list',
-		choices: processes
+		type: 'autocomplete',
+		source: (answers, input) => filterProcesses(input, processes)
+	}], answer => {
+		fkill(answer.processes).then(init);
+	});
+}
+
+function filterProcesses(input, processes) {
+	return new Promise(resolve => {
+		resolve(processes
+			.filter(proc => input ? proc.name.includes(input.toLowerCase()) : true)
 			.sort((a, b) => numSort.asc(a.pid, b.pid))
 			.map(proc => ({
 				name: `${proc.name} ${chalk.dim(proc.pid)}`,
 				value: proc.pid
 			}))
-	}], answer => {
-		fkill(answer.processes).then(init);
+		);
 	});
 }
 

--- a/package.json
+++ b/package.json
@@ -43,7 +43,8 @@
     "chalk": "^1.1.0",
     "esc-exit": "^1.0.0",
     "fkill": "^3.0.0",
-    "inquirer": "^0.11.0",
+    "inquirer": "^0.9.0",
+    "inquirer-autocomplete-prompt": "^0.1.3",
     "meow": "^3.3.0",
     "num-sort": "^1.0.0",
     "ps-list": "^3.0.0"


### PR DESCRIPTION
Had to downgrade `inquirer` since there were some issues with `0.10.x` and `0.11.x`. Doesn't affect our functionality anyway.

Fixes #5.