### PR TITLE
Fix bug where the filter of `procs` was returning no value

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -68,7 +68,7 @@ function filterProcesses(input, processes, flags) {
 			const name = cliTruncate(flags.verbose ? proc.cmd : proc.name, length, {position: 'middle'});
 			return {
 				name: `${name} ${chalk.dim(proc.pid)}`,
-				pid: proc.pid
+				value: proc.pid
 			};
 		});
 }


### PR DESCRIPTION
this addresses the bug found by @pirate on #14 