### PR TITLE
Enforce boolean type on flags

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -29,6 +29,8 @@ const cli = meow(`
 		f: 'force',
 		v: 'verbose'
 	}
+}, {
+	boolean: ['force', 'verbose']
 });
 
 const commandLineMargins = 4;

--- a/cli.js
+++ b/cli.js
@@ -28,9 +28,11 @@ const cli = meow(`
 	alias: {
 		f: 'force',
 		v: 'verbose'
-	}
-}, {
-	boolean: ['force', 'verbose']
+	},
+	boolean: [
+		'force',
+		'verbose'
+	]
 });
 
 const commandLineMargins = 4;


### PR DESCRIPTION
Fixes this command:

```
$ fkill -f zsh
```

to not ignore `zsh` input, because the CLI treats it like the value of `-f` flag.