### PR TITLE
Prevent force prompt if `force` flag is already supplied

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -99,6 +99,8 @@ function handleFkillError(processes) {
 
 if (cli.input.length === 0) {
 	init(cli.flags);
+} else if (cli.flags.force || cli.flags.f) {
+	fkill(cli.input, cli.flags);
 } else {
 	fkill(cli.input, cli.flags).catch(() => handleFkillError(cli.input));
 }

--- a/cli.js
+++ b/cli.js
@@ -99,8 +99,10 @@ function handleFkillError(processes) {
 
 if (cli.input.length === 0) {
 	init(cli.flags);
-} else if (cli.flags.force || cli.flags.f) {
-	fkill(cli.input, cli.flags);
 } else {
-	fkill(cli.input, cli.flags).catch(() => handleFkillError(cli.input));
+	const promise = fkill(cli.input, cli.flags);
+
+	if (!cli.flags.force) {
+		promise.catch(() => handleFkillError(cli.input));
+	}
 }


### PR DESCRIPTION
Hey all, thanks for this lovely piece of CLI 😍

However, no point asking the user to force kill the process or telling them to use `--force` when they already have it turned on. That's confusing.
