### PR TITLE
Add `--silent` flag

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -16,6 +16,7 @@ const cli = meow(`
 	Options
 	  --force -f    Force kill
 	  --verbose -v  Show process arguments
+	  --silent -s   Silently kill process
 
 	Examples
 	  $ fkill 1337
@@ -34,6 +35,10 @@ const cli = meow(`
 		verbose: {
 			type: 'boolean',
 			alias: 'v'
+		},
+		silent: {
+			type: 'boolean',
+			alias: 's'
 		}
 	}
 });
@@ -113,6 +118,9 @@ if (cli.input.length === 0) {
 	const promise = fkill(cli.input, Object.assign(cli.flags, {ignoreCase: true}));
 
 	if (!cli.flags.force) {
-		promise.catch(() => handleFkillError(cli.input));
+		promise.catch(() => {
+			if(!cli.flags.silent)
+				handleFkillError(cli.input)
+		});
 	}
 }

--- a/cli.js
+++ b/cli.js
@@ -16,7 +16,7 @@ const cli = meow(`
 	Options
 	  --force -f    Force kill
 	  --verbose -v  Show process arguments
-	  --silent -s   Silently kill process
+	  --silent -s   Silently kill and always exit with code 0
 
 	Examples
 	  $ fkill 1337

--- a/cli.js
+++ b/cli.js
@@ -119,8 +119,9 @@ if (cli.input.length === 0) {
 
 	if (!cli.flags.force) {
 		promise.catch(() => {
-			if(!cli.flags.silent)
-				handleFkillError(cli.input)
+			if (!cli.flags.silent) {
+				handleFkillError(cli.input);
+			}
 		});
 	}
 }

--- a/readme.md
+++ b/readme.md
@@ -31,8 +31,8 @@ $ fkill --help
   Options
     --force -f    Force kill
     --verbose -v  Show process arguments
-    --silent -s   Silently kill process
-  
+    --silent -s   Silently kill and always exit with code 0
+
   Examples
     $ fkill 1337
     $ fkill safari

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,8 @@ $ fkill --help
   Options
     --force -f    Force kill
     --verbose -v  Show process arguments
-
+    --silent -s   Silently kill process
+  
   Examples
     $ fkill 1337
     $ fkill safari


### PR DESCRIPTION
Usefull when:

- Closing all electron instances before building
- NPM scripts executed by code and not humans
- Killing of a process by name that may or may not is running
