### PR TITLE
Fix killing PID directly

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -30,6 +30,7 @@ const cli = meow(`
 	Run without arguments to use the interactive interface.
 	The process name is case insensitive.
 `, {
+	inferType: true,
 	flags: {
 		force: {
 			type: 'boolean',

--- a/fixture.js
+++ b/fixture.js
@@ -1,7 +1,8 @@
+'use strict';
 const http = require('http');
 
-const srv = http.createServer((req, res) => {
-	res.end();
+const server = http.createServer((request, response) => {
+	response.end();
 });
 
-srv.listen(process.argv.slice(2)[0]);
+server.listen(process.argv.slice(2)[0]);

--- a/fixture.js
+++ b/fixture.js
@@ -1,0 +1,7 @@
+const http = require('http');
+
+const srv = http.createServer((req, res) => {
+	res.end();
+});
+
+srv.listen(process.argv.slice(2)[0]);

--- a/package.json
+++ b/package.json
@@ -52,7 +52,10 @@
 	},
 	"devDependencies": {
 		"ava": "*",
+		"delay": "^2.0.0",
 		"execa": "^0.8.0",
+		"noop-process": "^3.1.0",
+		"process-exists": "^3.1.0",
 		"xo": "*"
 	}
 }

--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
 		"ava": "*",
 		"delay": "^2.0.0",
 		"execa": "^0.8.0",
+		"get-port": "^3.2.0",
 		"noop-process": "^3.1.0",
 		"process-exists": "^3.1.0",
 		"xo": "*"

--- a/test.js
+++ b/test.js
@@ -1,8 +1,10 @@
+import childProcess from 'child_process';
 import test from 'ava';
 import execa from 'execa';
 import delay from 'delay';
 import noopProcess from 'noop-process';
 import processExists from 'process-exists';
+import getPort from 'get-port';
 
 const noopProcessKilled = async (t, pid) => {
 	// Ensure the noop process has time to exit
@@ -19,4 +21,17 @@ test('pid', async t => {
 	const pid = await noopProcess();
 	await execa('./cli.js', ['--force', pid]);
 	await noopProcessKilled(t, pid);
+});
+
+test('kill from port', async t => {
+	const port = await getPort();
+	const pid = childProcess.spawn('node', ['fixture.js', port]).pid;
+	await execa('./cli.js', ['--force', pid]);
+	await noopProcessKilled(t, pid);
+	t.is(await getPort(port), port);
+});
+
+test('error when process is not found', async t => {
+	const err = await t.throws(execa('./cli.js', ['--force', 'notFoundProcess']));
+	t.regex(err.message, /Killing process notFoundProcess failed: Process doesn't exist/);
 });

--- a/test.js
+++ b/test.js
@@ -1,7 +1,22 @@
 import test from 'ava';
 import execa from 'execa';
+import delay from 'delay';
+import noopProcess from 'noop-process';
+import processExists from 'process-exists';
+
+const noopProcessKilled = async (t, pid) => {
+	// Ensure the noop process has time to exit
+	await delay(100);
+	t.false(await processExists(pid));
+};
 
 test(async t => {
 	const {stdout} = await execa('./cli.js', ['--version']);
 	t.true(stdout.length > 0);
+});
+
+test('pid', async t => {
+	const pid = await noopProcess();
+	await execa('./cli.js', ['--force', pid]);
+	await noopProcessKilled(t, pid);
 });


### PR DESCRIPTION
Since `fkill 1234` would interpret `1234` as a string, killing a PID directly doesn't work currently.