### PR TITLE
Show "use the force" prompt for process selected by inquirer prompt

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -116,8 +116,8 @@ const listProcesses = async (processes, flags) => {
 		source: async (answers, input) => filterProcesses(input, processes, flags)
 	}]);
 
-	fkill(answer.processes).catch(err => {
-		return handleFkillError(answer.processes);
+	fkill(answer.processes).catch(() => {
+		handleFkillError(answer.processes);
 	});
 };
 

--- a/cli.js
+++ b/cli.js
@@ -116,11 +116,9 @@ const listProcesses = async (processes, flags) => {
 		source: async (answers, input) => filterProcesses(input, processes, flags)
 	}]);
 
-	try {
-		fkill(answer.processes);
-	} catch (_) {
-		handleFkillError(answer.processes);
-	}
+	fkill(answer.processes).catch(err => {
+		return handleFkillError(answer.processes);
+	});
 };
 
 const init = async flags => {


### PR DESCRIPTION
Trying to kill a process that required force would previously cause an error:
```
jrw@confuser 2018-09-24 20:11:13 /cygdrive/c/Users/JackW/Documents/
λ fkill
? Running processes: node.exe 16644 :4873 :4874
AggregateError:
    Error: Killing process 16644 failed: ERROR: The process with PID 16644 (child process of PID 13424) could not be terminated.
    Reason: This process can only be terminated forcefully (with /F option).
        at Array.map (<anonymous>)
        at processExists.all.then.then (C:/Users/JackW/AppData/Roaming/npm/node_modules/fkill-cli/node_modules/fkill/index.js:83:10)
    at processExists.all.then.then (C:\Users\JackW\AppData\Roaming\npm\node_modules\fkill-cli\node_modules\fkill\index.js:83:10)
    at process._tickCallback (internal/process/next_tick.js:68:7)
```