### PR TITLE
Force kill if normal kill fails

### DIFF
--- a/fixture.js
+++ b/fixture.js
@@ -1,6 +1,8 @@
 'use strict';
 const http = require('http');
 
+process.on('SIGTERM', () => {});
+
 const server = http.createServer((request, response) => {
 	response.end();
 });

--- a/test.js
+++ b/test.js
@@ -26,7 +26,7 @@ test('pid', async t => {
 test('kill from port', async t => {
 	const port = await getPort();
 	const {pid} = childProcess.spawn('node', ['fixture.js', port]);
-	await execa('./cli.js', ['--force', pid]);
+	await execa('./cli.js', [pid]);
 	await noopProcessKilled(t, pid);
 	t.is(await getPort({port}), port);
 });


### PR DESCRIPTION
Forces a kill if the normal kill behavior fails. `handleFkillError` already includes functionality for handling the case of a failed kill, but `fkill` doesn't throw an error when it fails to kill a process, so I chose a different way to implement this feature.

Resolves #42