### PR TITLE
Show CPU and memory usage in interactive mode

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -21,7 +21,9 @@ const cli = meow(`
 
 	To kill a port, prefix it with a colon. For example: :8080.
 
-	Run without arguments to use the interactive interface.
+	Run without arguments to use the interactive mode.
+	In interactive mode, 🚦A.B% indicates high CPU usage, 🐏C.D% indicates high memory usage.
+
 	The process name is case insensitive.
 `, {
 	inferType: true,

--- a/interactive.js
+++ b/interactive.js
@@ -22,7 +22,7 @@ const nameFilter = (input, proc) => {
 
 const preferNotMatching = matches => (a, b) => {
 	const aMatches = matches(a);
-	return (matches(b) === aMatches) ? 0 : (aMatches ? 1 : -1);
+	return matches(b) === aMatches ? 0 : (aMatches ? 1 : -1);
 };
 
 const deprioritizedProcesses = new Set(['iTerm', 'iTerm2', 'fkill']);

--- a/interactive.js
+++ b/interactive.js
@@ -79,10 +79,10 @@ const filterProcesses = (input, processes, flags) => {
 			const margins = commandLineMargins + proc.pid.toString().length + ports.length + memory.length + cpu.length;
 			const length = lineLength - margins;
 			const name = cliTruncate(flags.verbose && process.platform !== 'win32' ? proc.cmd : proc.name, length, {position: 'middle'});
-			const spacer = (lineLength === process.stdout.columns) ? ''.padEnd(length - name.length) : '';
+			const spacer = lineLength === process.stdout.columns ? ''.padEnd(length - name.length) : '';
 
 			return {
-				name: `${name} ${chalk.dim(proc.pid)}${spacer}${chalk.dim.magenta(ports)}${cpu}${memory}`,
+				name: `${name} ${chalk.dim(proc.pid)}${spacer}${chalk.dim(ports)}${cpu}${memory}`,
 				value: proc.pid
 			};
 		});
@@ -147,6 +147,7 @@ const init = async flags => {
 		pidFromPort.list(),
 		psList({all: false})
 	]);
+
 	const procs = processes.map(proc => ({...proc, ports: getPortsFromPid(proc.pid, pids)}));
 	listProcesses(procs, flags);
 };


### PR DESCRIPTION
Fixes #62 .

Style and thresholds might be opinionated, but I tuned them to the point I was comfortable finding processes.

- processes are sorted by sum of cpu and memory usage(percentage), highest first
- in verbose mode memory and cpu usage is show when it is above 0.1% (minimal number we can get)
- in non-verbose mode memory usage is shown when it's above 0.5%, cpu usage shown when it's above 2%
- cpu usage is shown in dark red
- memory usage is shown in dark yellow