### PR TITLE
Make interactive mode work under Windows

### DIFF
--- a/interactive.js
+++ b/interactive.js
@@ -29,8 +29,25 @@ const preferNotMatching = matches => (a, b) => {
 const deprioritizedProcesses = new Set(['iTerm', 'iTerm2', 'fkill']);
 const isDeprioritizedProcess = process_ => deprioritizedProcesses.has(process_.name);
 const preferNotDeprioritized = preferNotMatching(isDeprioritizedProcess);
-const preferHighPerformanceImpact = (a, b) => numSort.descending(a.cpu + a.memory, b.cpu + b.memory);
 const preferLowAlphanumericNames = (a, b) => a.name.localeCompare(b.name);
+const preferHighPerformanceImpact = (a, b) => {
+	const haveCpu = (typeof a.cpu === 'number') && (typeof b.cpu === 'number');
+	const haveMemory = (typeof a.memory === 'number') && (typeof b.memory === 'number');
+
+	if (haveCpu && haveMemory) {
+		return numSort.descending(a.cpu + a.memory, b.cpu + b.memory);
+	}
+
+	if (haveCpu) {
+		return numSort.descending(a.cpu, b.cpu);
+	}
+
+	if (haveMemory) {
+		return numSort.descending(a.memory, b.memory);
+	}
+
+	return 0;
+};
 
 const preferHeurisicallyInterestingProcesses = (a, b) => {
 	let result;

--- a/interactive.js
+++ b/interactive.js
@@ -30,19 +30,20 @@ const deprioritizedProcesses = new Set(['iTerm', 'iTerm2', 'fkill']);
 const isDeprioritizedProcess = process_ => deprioritizedProcesses.has(process_.name);
 const preferNotDeprioritized = preferNotMatching(isDeprioritizedProcess);
 const preferLowAlphanumericNames = (a, b) => a.name.localeCompare(b.name);
-const preferHighPerformanceImpact = (a, b) => {
-	const haveCpu = (typeof a.cpu === 'number') && (typeof b.cpu === 'number');
-	const haveMemory = (typeof a.memory === 'number') && (typeof b.memory === 'number');
 
-	if (haveCpu && haveMemory) {
+const preferHighPerformanceImpact = (a, b) => {
+	const hasCpu = typeof a.cpu === 'number' && typeof b.cpu === 'number';
+	const hasMemory = typeof a.memory === 'number' && typeof b.memory === 'number';
+
+	if (hasCpu && hasMemory) {
 		return numSort.descending(a.cpu + a.memory, b.cpu + b.memory);
 	}
 
-	if (haveCpu) {
+	if (hasCpu) {
 		return numSort.descending(a.cpu, b.cpu);
 	}
 
-	if (haveMemory) {
+	if (hasMemory) {
 		return numSort.descending(a.memory, b.memory);
 	}
 


### PR DESCRIPTION
Check if `cpu` and `memory` fields are present in interactive mode, which was the cause of exception thrown before.

(Added separate checks for both fields in case they get partially implemented in `ps-list` later.)

Fixes #68.

