### PR TITLE
Add `--force-after-timeout` / `-t` option

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -8,9 +8,10 @@ const cli = meow(`
 	  $ fkill [<pid|name|:port> …]
 
 	Options
-	  --force -f    Force kill
-	  --verbose -v  Show process arguments
-	  --silent -s   Silently kill and always exit with code 0
+	  --force, -f                        Force kill
+	  --verbose, -v                      Show process arguments
+	  --silent, -s                       Silently kill and always exit with code 0
+	  --force-after-timeout <N>, -t <N>  Force kill processes which didn't exit after N seconds
 
 	Examples
 	  $ fkill 1337
@@ -39,6 +40,10 @@ const cli = meow(`
 		silent: {
 			type: 'boolean',
 			alias: 's'
+		},
+		forceAfterTimeout: {
+			type: 'number',
+			alias: 't'
 		}
 	}
 });
@@ -46,7 +51,8 @@ const cli = meow(`
 if (cli.input.length === 0) {
 	require('./interactive').init(cli.flags);
 } else {
-	const promise = fkill(cli.input, {...cli.flags, ignoreCase: true});
+	const forceAfterTimeout = cli.flags.forceAfterTimeout === undefined ? undefined : cli.flags.forceAfterTimeout * 1000;
+	const promise = fkill(cli.input, {...cli.flags, forceAfterTimeout, ignoreCase: true});
 
 	if (!cli.flags.force) {
 		promise.catch(error => {

--- a/readme.md
+++ b/readme.md
@@ -23,27 +23,28 @@ $ npm install --global fkill-cli
 ```
 $ fkill --help
 
-  Usage
-    $ fkill [<pid|name> …]
+	Usage
+	  $ fkill [<pid|name|:port> …]
 
-  Options
-    --force -f    Force kill
-    --verbose -v  Show process arguments
-    --silent -s   Silently kill and always exit with code 0
+	Options
+	  --force, -f                  Force kill
+	  --verbose, -v                Show process arguments
+	  --silent, -s                 Silently kill and always exit with code 0
+	  --force-timeout <N>, -t <N>  Force kill processes which didn't exit after N seconds
 
-  Examples
-    $ fkill 1337
-    $ fkill safari
-    $ fkill :8080
-    $ fkill 1337 safari :8080
-    $ fkill
+	Examples
+	  $ fkill 1337
+	  $ fkill safari
+	  $ fkill :8080
+	  $ fkill 1337 safari :8080
+	  $ fkill
 
-  To kill a port, prefix it with a colon. For example: :8080.
+	To kill a port, prefix it with a colon. For example: :8080.
 
-  Run without arguments to use the interactive interface.
-  In interactive mode, 🚦n% indicates high CPU usage and 🐏n% indicates high memory usage.
+	Run without arguments to use the interactive mode.
+	In interactive mode, 🚦n% indicates high CPU usage and 🐏n% indicates high memory usage.
 
-  The process name is case insensitive.
+	The process name is case insensitive.
 ```
 
 ## Interactive UI


### PR DESCRIPTION
Add option `--force-after-timeout N` / `-t N`, to force kill processes which didn't exit within timeout seconds.

In interactive mode, wait up to 3 seconds for processes to exit, then prompt user to force kill surviving processes.

Fixes #42
Requires sindresorhus/fkill#45


<!-- Issuehunt content -->

---

<details>
<summary>
<b>IssueHunt Summary</b>
</summary>

### Referenced issues

This pull request has been submitted to:
- [#42: Process is not killed](https://issuehunt.io/repos/37787433/issues/42)
---
</details>
<!-- /Issuehunt content-->